### PR TITLE
feat: add `no-useless-iife` to the config

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,13 @@ module.exports = {
 		// x-release-please-end
 	},
 	configs: {
-		config,
+		config: {
+			...config,
+			rules: {
+				...config.rules,
+				'transloadit/no-useless-iife': 'error',
+			},
+		},
 	},
 	rules: {
 		'no-useless-iife': require('./rules/no-useless-iife'),


### PR DESCRIPTION
@mifi wdyt?

This would make the plugin's config extend `eslint-config-transloadit` with our custom rules, `eslint-config-transloadit` can still go on with its life for defining all rules but custom ones.